### PR TITLE
2 シンボルグリフを決定する

### DIFF
--- a/includes/nm.h
+++ b/includes/nm.h
@@ -43,6 +43,7 @@ bool	analyze_header(t_analysis* analysis);
 
 // symbol.c
 void	determine_section_category(const t_master* m, const t_analysis* analysis, t_section_unit* section);
+void	determine_symbol_name(const t_master* m, const t_analysis* analysis, const t_table_pair* table_pair, t_symbol_unit* symbol);
 void	determine_symbol_griff(const t_master* m, const t_analysis* analysis, t_symbol_unit* symbol);
 
 // basic_utils.c

--- a/includes/nm.h
+++ b/includes/nm.h
@@ -30,10 +30,11 @@ void	map_elf64_header(const t_elf_64_header* defined, t_object_header* original)
 void	map_elf32_header(const t_elf_32_header* defined, t_object_header* original);
 void	map_elf64_section_header(const t_elf_64_section_header* defined, t_section_unit* original);
 void	map_elf32_section_header(const t_elf_32_section_header* defined, t_section_unit* original);
-void	map_elf64_symbol(const t_elf_64_symbol* defined, const t_string_table_unit* string_table, t_symbol_unit* original);
-void	map_elf32_symbol(const t_elf_32_symbol* defined, const t_string_table_unit* string_table, t_symbol_unit* original);
+void	map_elf64_symbol(const t_elf_64_symbol* defined, t_symbol_unit* original);
+void	map_elf32_symbol(const t_elf_32_symbol* defined, t_symbol_unit* original);
 void	map_section_to_symbol_table(const t_section_unit* section, t_symbol_table_unit* table);
 void	map_section_to_string_table(const t_section_unit* section, t_string_table_unit* table);
+const t_section_unit*	get_referencing_section(const t_master* m, const t_analysis* analysis, const t_symbol_unit* symbol);
 
 // analysis.c
 bool	analyze_file(t_master* m, const char* target_path);

--- a/includes/structure.h
+++ b/includes/structure.h
@@ -118,7 +118,7 @@ typedef struct s_symbol_list_node
 	t_symbol_table_unit symbol_table;
 	t_string_table_unit string_table;
 	struct s_symbol_list_node *next;
-} t_symbol_list_node;
+} t_table_pair;
 
 typedef struct s_object_header {
 	size_t	hsize;     // ヘッダのサイズ
@@ -151,7 +151,7 @@ typedef struct s_analysis
 	t_section_unit*	sections;    // セクション構造体の配列; 要素数は num_section に等しい
 	
 	size_t				num_symbol_table;
-	t_symbol_list_node*	symbol_tables; // シンボルテーブルの配列
+	t_table_pair*	symbol_tables; // シンボルテーブルの配列
 
 	size_t			num_symbol;           // このファイルに存在するであろうシンボルの総数
 	size_t			num_symbol_effective; // ↑ のうち, 表示対象となるシンボルの数

--- a/includes/structure.h
+++ b/includes/structure.h
@@ -6,6 +6,9 @@
 # include <stdbool.h>
 # include <elf.h>
 
+// 事前宣言
+struct s_section_unit;
+
 // type alias
 typedef Elf64_Ehdr t_elf_64_header;
 typedef Elf64_Shdr t_elf_64_section_header;
@@ -62,6 +65,8 @@ typedef struct s_symbol_unit {
 	bool		is_debug;     // デバッグシンボルかどうか(-a)
 	bool		is_global;    // 外部シンボルかどうか(-g)
 	bool		is_undefined; // 未定義シンボルかどうか(-u)
+
+	const struct s_section_unit*	relevant_section;
 } t_symbol_unit;
 
 // (32/64ビット共通)

--- a/includes/structure.h
+++ b/includes/structure.h
@@ -44,10 +44,16 @@ typedef enum e_section_category {
 	SC_TEXT,
 	// BSSセクション
 	SC_BSS,
+	// 
+	SC_MERGEABLE_CHARACTER,
+	// デバッグセクション
+	SC_DEBUG,
 	// 未定義セクション
 	SC_UNDEFINED,
 	SC_OTHER,
 }	t_section_category;
+
+# define SYMGRIFF_UNKNOWN '?'
 
 typedef struct s_symbol_unit {
 	size_t		address;      // シンボルのアドレス
@@ -81,6 +87,7 @@ typedef struct s_section_unit {
 	size_t		offset; // セクションのファイルオフセット
 	size_t		entsize; // エントリーサイズ
 	size_t		size; // セクションのサイズ
+	uint64_t	info;
 
 	t_section_category category;
 } t_section_unit;

--- a/srcs/analysis.c
+++ b/srcs/analysis.c
@@ -56,11 +56,12 @@ void	extract_sections(t_master* m, t_analysis* analysis, const void* section_hea
 			section->name = NULL;
 		}
 		determine_section_category(m, analysis, section);
-		DEBUGINFO("section: %zu(%zx) -> %s(%llx)\t%s\t%c%c%c%c%c%c%c%c%c%c%c%c%c%c %b\t%s",
+		DEBUGINFO("section: %zu(%zx) -> %s(%llx)\t%s %llu\t%c%c%c%c%c%c%c%c%c%c%c%c%c%c %b\t%s",
 			i,
 			section->offset,
 			sectiontype_to_name(section->type), section->type,
 			section_category_to_name(section->category),
+			section->link,
 			(section->flags & SHF_WRITE)			? 'w' : '-',
 			(section->flags & SHF_ALLOC)			? 'a' : '-',
 			(section->flags & SHF_EXECINSTR)		? 'x' : '-',
@@ -205,10 +206,17 @@ static bool	should_print_address(const t_symbol_unit* symbol) {
 	return symbol->shndx != SHN_UNDEF;
 }
 
+static bool should_print_symbol(const t_symbol_unit* symbol) {
+	if (symbol->symbol_griff == 'U' && ft_strnlen(symbol->name, 1) == 0) { return false; }
+	if (symbol->name[0] == '$' && ft_strnlen(symbol->name, 3) == 2) { return false; }
+	return true;
+}
+
 void	print_symbols(const t_analysis* analysis) {
 	const size_t	addr_width = 16;
 	for (size_t i = 0; i < analysis->num_symbol_effective; ++i) {
 		t_symbol_unit*	symbol = analysis->sorted_symbols[i];
+		if (!should_print_symbol(symbol)) { continue; }
 
 		// [アドレスの表示]
 		if (!should_print_address(symbol)) {

--- a/srcs/analysis.c
+++ b/srcs/analysis.c
@@ -91,7 +91,7 @@ void extract_symbol_tables(t_analysis* analysis) {
 				size_t	string_table_index = section->link;
 				YOYO_ASSERT(string_table_index < analysis->num_section);
 				t_section_unit*	strtab_section = &analysis->sections[string_table_index];
-				t_symbol_list_node* symbol_pair = &analysis->symbol_tables[i_symbol_table];
+				t_table_pair* symbol_pair = &analysis->symbol_tables[i_symbol_table];
 
 				// [シンボルテーブルと文字列テーブルをペアにする]
 				map_section_to_symbol_table(section, &symbol_pair->symbol_table);
@@ -107,7 +107,7 @@ void	extract_symbols(t_master* m, t_analysis* analysis) {
 	analysis->num_symbol_effective = 0;
 	size_t i_symbol = 0;
 	for (size_t i_symbol_table = 0; i_symbol_table < analysis->num_symbol_table; ++i_symbol_table) {
-		t_symbol_list_node*	node = &analysis->symbol_tables[i_symbol_table];
+		t_table_pair*	node = &analysis->symbol_tables[i_symbol_table];
 		t_symbol_table_unit* symbol_table = &node->symbol_table;
 		t_string_table_unit* string_table = &node->string_table;
 		DEBUGINFO("symbol table: %zu: %s %s",
@@ -130,6 +130,9 @@ void	extract_symbols(t_master* m, t_analysis* analysis) {
 					print_error_by_message(m, "SOMETHING WRONG");
 					break;
 			}
+			// シンボル名をセットする
+			determine_symbol_name(m, analysis, node, symbol_unit);
+
 			// シンボルグリフを決定する
 			determine_symbol_griff(m, analysis, symbol_unit);
 			current_symbol += symbol_table->entry_size;
@@ -259,7 +262,7 @@ bool	analyze_file(t_master* m, const char* target_path) {
 
 	// シンボルユニット配列を用意する
 	YOYO_ASSERT(analysis->num_symbol_table > 0);
-	analysis->symbol_tables = malloc(sizeof(t_symbol_list_node) * analysis->num_symbol_table);
+	analysis->symbol_tables = malloc(sizeof(t_table_pair) * analysis->num_symbol_table);
 	YOYO_ASSERT(analysis->symbol_tables != NULL);
 	
 	// [シンボルテーブルがあったら, 対応する文字列テーブルとペアにして配列に入れていく]

--- a/srcs/names.c
+++ b/srcs/names.c
@@ -11,8 +11,8 @@ const char* elfclass_to_name(int value) {
 }
 
 const char* sectiontype_to_name(int value) {
-	static const char* names[] = (const char* []){"SHT_DYNAMIC", "SHT_DYNSYM", "SHT_FINI_ARRAY", "SHT_HASH", "SHT_HIPROC", "SHT_HIUSER", "SHT_INIT_ARRAY", "SHT_LOPROC", "SHT_LOUSER", "SHT_NOBITS", "SHT_NOTE", "SHT_NULL", "SHT_PREINIT_ARRAY", "SHT_PROGBITS", "SHT_REL", "SHT_RELA", "SHT_SHLIB", "SHT_STRTAB", "SHT_SYMTAB", "SHT_GNU_verdef", "SHT_GNU_verneed", "SHT_GNU_versym"};
-	static const int values[] = (int []){ SHT_DYNAMIC, SHT_DYNSYM, SHT_FINI_ARRAY, SHT_HASH, SHT_HIPROC, SHT_HIUSER, SHT_INIT_ARRAY, SHT_LOPROC, SHT_LOUSER, SHT_NOBITS, SHT_NOTE, SHT_NULL, SHT_PREINIT_ARRAY, SHT_PROGBITS, SHT_REL, SHT_RELA, SHT_SHLIB, SHT_STRTAB, SHT_SYMTAB, SHT_GNU_verdef, SHT_GNU_verneed, SHT_GNU_versym };
+	static const char* names[] = (const char* []){"SHT_DYNAMIC", "SHT_DYNSYM", "SHT_FINI_ARRAY", "SHT_HASH", "SHT_HIPROC", "SHT_HIUSER", "SHT_INIT_ARRAY", "SHT_LOPROC", "SHT_LOUSER", "SHT_NOBITS", "SHT_NOTE", "SHT_NULL", "SHT_PREINIT_ARRAY", "SHT_PROGBITS", "SHT_REL", "SHT_RELA", "SHT_SHLIB", "SHT_STRTAB", "SHT_SYMTAB", "SHT_GNU_verdef", "SHT_GNU_verneed", "SHT_GNU_versym", "SHT_GNU_HASH"};
+	static const int values[] = (int []){ SHT_DYNAMIC, SHT_DYNSYM, SHT_FINI_ARRAY, SHT_HASH, SHT_HIPROC, SHT_HIUSER, SHT_INIT_ARRAY, SHT_LOPROC, SHT_LOUSER, SHT_NOBITS, SHT_NOTE, SHT_NULL, SHT_PREINIT_ARRAY, SHT_PROGBITS, SHT_REL, SHT_RELA, SHT_SHLIB, SHT_STRTAB, SHT_SYMTAB, SHT_GNU_verdef, SHT_GNU_verneed, SHT_GNU_versym, SHT_GNU_HASH };
 	for (size_t i = 0; i < sizeof(names) / sizeof(char *); ++i) { if (value == values[i]) { return names[i]; } }
 	return "UNKNOWN";
 }

--- a/srcs/structure_mapping.c
+++ b/srcs/structure_mapping.c
@@ -44,10 +44,32 @@ void	map_elf32_section_header(const t_elf_32_section_header* defined, t_section_
 	original->size = defined->sh_size;
 }
 
+const t_section_unit*	get_referencing_section(const t_master* m, const t_analysis* analysis, const t_symbol_unit* symbol) {
+	(void)m;
+	(void)analysis;
+	(void)symbol;
+
+	switch (symbol->shndx) {
+		case SHN_UNDEF:
+		case SHN_BEFORE:
+		case SHN_AFTER:
+		// case SHN_AMD64_LCOMMON:
+		// case SHN_SUNW_IGNORE:
+		case SHN_ABS:
+		case SHN_COMMON:
+		case SHN_XINDEX:
+			break;
+		default:
+			YOYO_ASSERT(symbol->shndx < analysis->num_section);
+			return &analysis->sections[symbol->shndx];
+	}
+	return NULL;
+}
+
 // ELF64シンボル構造体をシンボル構造体にマップする
-void	map_elf64_symbol(const t_elf_64_symbol* defined, const t_string_table_unit* string_table, t_symbol_unit* original) {
+void	map_elf64_symbol(const t_elf_64_symbol* defined, t_symbol_unit* original) {
 	original->address = defined->st_value;
-	original->name = string_table->head + defined->st_name;
+	original->name = NULL;
 	original->name_offset = defined->st_name;
 	original->symbol_griff = '?';
 
@@ -64,9 +86,9 @@ void	map_elf64_symbol(const t_elf_64_symbol* defined, const t_string_table_unit*
 }
 
 // ELF32シンボル構造体をシンボル構造体にマップする
-void	map_elf32_symbol(const t_elf_32_symbol* defined, const t_string_table_unit* string_table, t_symbol_unit* original) {
+void	map_elf32_symbol(const t_elf_32_symbol* defined, t_symbol_unit* original) {
 	original->address = defined->st_value;
-	original->name = string_table->head + defined->st_name;
+	original->name = NULL;
 	original->name_offset = defined->st_name;
 	original->symbol_griff = '?';
 

--- a/srcs/structure_mapping.c
+++ b/srcs/structure_mapping.c
@@ -30,6 +30,7 @@ void	map_elf64_section_header(const t_elf_64_section_header* defined, t_section_
 	original->offset = defined->sh_offset;
 	original->entsize = defined->sh_entsize;
 	original->size = defined->sh_size;
+	original->info = defined->sh_info;
 }
 
 // ELF32セクションヘッダ構造体をセクション構造体にマップする
@@ -42,6 +43,7 @@ void	map_elf32_section_header(const t_elf_32_section_header* defined, t_section_
 	original->offset = defined->sh_offset;
 	original->entsize = defined->sh_entsize;
 	original->size = defined->sh_size;
+	original->info = defined->sh_info;
 }
 
 const t_section_unit*	get_referencing_section(const t_master* m, const t_analysis* analysis, const t_symbol_unit* symbol) {
@@ -71,7 +73,7 @@ void	map_elf64_symbol(const t_elf_64_symbol* defined, t_symbol_unit* original) {
 	original->address = defined->st_value;
 	original->name = NULL;
 	original->name_offset = defined->st_name;
-	original->symbol_griff = '?';
+	original->symbol_griff = SYMGRIFF_UNKNOWN;
 
 	original->bind = ELF64_ST_BIND(defined->st_info);
 	original->type = ELF64_ST_TYPE(defined->st_info);
@@ -90,7 +92,7 @@ void	map_elf32_symbol(const t_elf_32_symbol* defined, t_symbol_unit* original) {
 	original->address = defined->st_value;
 	original->name = NULL;
 	original->name_offset = defined->st_name;
-	original->symbol_griff = '?';
+	original->symbol_griff = SYMGRIFF_UNKNOWN;
 
 	original->bind = ELF32_ST_BIND(defined->st_info);
 	original->type = ELF32_ST_TYPE(defined->st_info);

--- a/srcs/symbol.c
+++ b/srcs/symbol.c
@@ -79,6 +79,25 @@ const t_section_unit*	get_referencing_section(const t_master* m, const t_analysi
 	return NULL;
 }
 
+// シンボルの名前 name を決定する
+void	determine_symbol_name(
+	const t_master* m,
+	const t_analysis* analysis,
+	const t_table_pair* table_pair,
+	t_symbol_unit* symbol
+) {
+	(void)m;
+	if (symbol->type == STT_SECTION) {
+		// セクションシンボル
+		const t_section_unit* section = &analysis->sections[symbol->shndx];
+		symbol->name = section->name;
+		return;
+	} else {
+		const t_string_table_unit* string_table = &table_pair->string_table;
+		symbol->name = string_table->head + symbol->name_offset;
+	}
+}
+
 // グローバルなデバッグ情報シンボル
 // ローカルなデバッグ情報シンボル
 // スタックまたはその他の未定義セクションシンボル
@@ -94,7 +113,7 @@ void	determine_symbol_griff(const t_master* m, const t_analysis* analysis, t_sym
 
 	const t_section_unit*	referencing_section = get_referencing_section(m, analysis, symbol);
 
-	DEBUGOUT("|%s| bind:%s type:%s section-cat:%s shndx:%zu %llu %llu %u addr: %p value: %llu size: %llu",
+	DEBUGOUT("|%s| bind:%s type:%s section-cat:%s shndx:%zu %llu %llu %u addr: %p value: %llx size: %llu",
 		symbol->name,
 		symbinding_to_name(symbol->bind),
 		symtype_to_name(symbol->type),


### PR DESCRIPTION
Linuxにおいて`./ft_nm a.out`と`nm -a a.out`が一致する状態まで持ってきた