### PR TITLE
support: not NUL-terminated string table for symbol name

### DIFF
--- a/includes/nm.h
+++ b/includes/nm.h
@@ -19,7 +19,7 @@
 # include "libft.h"
 
 // file.c
-bool	mmap_target_file(const t_master* m, const char* path, t_target_file* target);
+bool	deploy_analysis(const t_master* m, const char* path, t_target_file* target);
 void	destroy_target_file(const t_master* m, const t_target_file* target);
 
 // nm.c

--- a/includes/structure.h
+++ b/includes/structure.h
@@ -91,12 +91,12 @@ typedef struct s_section_unit {
 	uint64_t	type;        // タイプ
 	uint64_t	flags;       // フラグ
 	uint64_t	link;        // リンク先
-	void*		head;        // セクションのメモリマップアドレス
+	void*		head_addr;   // セクションのメモリマップアドレス
 	size_t		offset;      // セクションのファイルオフセット
 	size_t		entsize;     // エントリーサイズ
 	size_t		size;        // セクションのサイズ
 	uint64_t	info;
-
+	// [ELFの先頭アドレス] + offset = head_addr が成り立つ
 	t_section_category category;
 } t_section_unit;
 
@@ -123,11 +123,13 @@ typedef struct s_string_table_unit
 {
 	const t_section_unit*	section;
 	// 実際の文字列テーブルの先頭アドレス
-	void *head;
+	void*	head_addr;
 	// ELFファイル先頭からのオフセット
-	size_t offset;
+	size_t	offset;
 	// 文字列テーブル全体のサイズ
-	size_t total_size;
+	size_t	total_size;
+	// NUL-terminated かどうか
+	bool	is_terminated;
 } t_string_table_unit;
 
 // (32/64ビット共通)
@@ -158,7 +160,7 @@ typedef struct s_target_file
 {
 	const char *path;
 	// memmap された対象ファイルの先頭アドレス
-	void *head;
+	void *head_addr;
 	// 対象ファイルの真のサイズ
 	size_t size;
 } t_target_file;

--- a/srcs/file.c
+++ b/srcs/file.c
@@ -1,7 +1,7 @@
 #include "nm.h"
 
 // path にある対象ファイルをメモリ上に展開し, 情報を target にセットする.
-bool	mmap_target_file(const t_master* m, const char* path, t_target_file* target) {
+bool	deploy_analysis(const t_master* m, const char* path, t_target_file* target) {
 	int fd = open(path, O_RDONLY);
 	if (fd < 0) {
 		if (errno == ENOENT) {
@@ -56,13 +56,13 @@ bool	mmap_target_file(const t_master* m, const char* path, t_target_file* target
 	}
 
 	target->path = path;
-	target->head = mem;
+	target->head_addr = mem;
 	target->size = size;
 	return true;
 }
 
 void	destroy_target_file(const t_master* m, const t_target_file* target) {
-	if (munmap(target->head, target->size)) {
+	if (munmap(target->head_addr, target->size)) {
 		print_unrecoverable_generic_error_by_errno(m, target->path);
 	}
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -71,6 +71,7 @@ int main(int argc, char** argv) {
 	}
 
 	int status = 0;
+	// [対象ファイルの解析]
 	for (master.i = 0; master.i < master.num_target; ++master.i) {
 		if (!analyze_file(&master, master.target_names[master.i])) {
 			status = (status + 1) % 256;

--- a/srcs/structure_mapping.c
+++ b/srcs/structure_mapping.c
@@ -118,7 +118,7 @@ void	map_elf32_symbol(const t_analysis* analysis, const t_elf_32_symbol* defined
 // セクションユニット構造体をシンボルテーブル構造体にマップする
 void	map_section_to_symbol_table(const t_section_unit* section, t_symbol_table_unit* table) {
 	table->section = section;
-	table->head = section->head;
+	table->head = section->head_addr;
 	table->offset = section->offset;
 	table->entry_size = section->entsize;
 	table->total_size = section->size;
@@ -131,10 +131,20 @@ void	map_section_to_symbol_table(const t_section_unit* section, t_symbol_table_u
 
 // セクションユニット構造体を文字列テーブル構造体にマップする
 void	map_section_to_string_table(const t_section_unit* section, t_string_table_unit* table) {
+	// TODO: 境界チェックを行う
+	// - head_addr がマッピング領域内にあるか
+	// - head_addr + total_size がマッピング領域内にあるか
+
 	table->section = section;
-	table->head = section->head;
+	table->head_addr = section->head_addr;
 	table->offset = section->offset;
 	table->total_size = section->size;
+	if (table->total_size > 0) {
+		const char*	strtab = table->head_addr + table->total_size - 1;
+		table->is_terminated = *strtab == '\0';
+	} else {
+		table->is_terminated = false;
+	}
 }
 
 

--- a/srcs/symbol.c
+++ b/srcs/symbol.c
@@ -15,7 +15,11 @@ void	determine_symbol_name(
 		return;
 	} else {
 		const t_string_table_unit* string_table = &table_pair->string_table;
-		symbol->name = string_table->head + symbol->name_offset;
+		if (string_table->is_terminated) {
+			symbol->name = string_table->head_addr + symbol->name_offset;
+		} else {
+			symbol->name = NULL;
+		}
 	}
 }
 


### PR DESCRIPTION
シンボル名文字列テーブルがNUL-terminatedでない場合, セクションシンボルでないシンボル名をすべて`NULL`にする。

・・・ただし, binutilsの`nm`は若干説明がつかない挙動をする:
`none`の文字列テーブルを破壊したものにおいて、シンボル名""と"Scrt1.o"は名前が表示される。

この挙動に対するロジカルな説明が思いつかないので、とりあえず真似しないことにする。
