### PR TITLE
文字列テーブルの境界チェック

### DIFF
--- a/includes/nm.h
+++ b/includes/nm.h
@@ -46,7 +46,7 @@ bool	analyze_header(const t_master* m, t_analysis* analysis);
 void	determine_section_category(const t_master* m, const t_analysis* analysis, t_section_unit* section);
 
 // symbol.c
-void	determine_symbol_name(const t_master* m, const t_analysis* analysis, const t_table_pair* table_pair, t_symbol_unit* symbol);
+bool	determine_symbol_name(const t_master* m, const t_analysis* analysis, const t_table_pair* table_pair, t_symbol_unit* symbol);
 void	determine_symbol_griff(const t_master* m, const t_analysis* analysis, t_symbol_unit* symbol);
 
 // basic_utils.c

--- a/includes/structure.h
+++ b/includes/structure.h
@@ -92,7 +92,7 @@ typedef struct s_section_unit {
 	uint64_t	flags;       // フラグ
 	uint64_t	link;        // リンク先
 	void*		head_addr;   // セクションのメモリマップアドレス
-	size_t		offset;      // セクションのファイルオフセット
+	size_t		sec_offset;      // セクションのファイルオフセット
 	size_t		entsize;     // エントリーサイズ
 	size_t		size;        // セクションのサイズ
 	uint64_t	info;

--- a/srcs/file.c
+++ b/srcs/file.c
@@ -58,6 +58,7 @@ bool	deploy_analysis(const t_master* m, const char* path, t_target_file* target)
 	target->path = path;
 	target->head_addr = mem;
 	target->size = size;
+	// DEBUGINFO("mmapped: [%p, %p), size: %zu", mem, mem + size, size);
 	return true;
 }
 

--- a/srcs/print_utils.c
+++ b/srcs/print_utils.c
@@ -52,7 +52,7 @@ void	print_chars(int fd, char ch, uint64_t n) {
 void	debug_print_section(const t_section_unit* section) {
 	(void)section;
 	DEBUGINFO("sec: %zx -> %s(t:%llx)\t%s li:%llu\t%c%c%c%c%c%c%c%c%c%c%c%c%c%c %b\t%s",
-		section->offset,
+		section->sec_offset,
 		sectiontype_to_name(section->type), section->type,
 		section_category_to_name(section->category),
 		section->link,

--- a/srcs/structure_mapping.c
+++ b/srcs/structure_mapping.c
@@ -34,7 +34,7 @@ void	map_elf64_section_header(const t_analysis* analysis, const t_elf_64_section
 	original->type        = SWAP_NEEDED(analysis, defined->sh_type);
 	original->flags       = SWAP_NEEDED(analysis, defined->sh_flags);
 	original->link        = SWAP_NEEDED(analysis, defined->sh_link);
-	original->offset      = SWAP_NEEDED(analysis, defined->sh_offset);
+	original->sec_offset  = SWAP_NEEDED(analysis, defined->sh_offset);
 	original->entsize     = SWAP_NEEDED(analysis, defined->sh_entsize);
 	original->size        = SWAP_NEEDED(analysis, defined->sh_size);
 	original->info        = SWAP_NEEDED(analysis, defined->sh_info);
@@ -47,7 +47,7 @@ void	map_elf32_section_header(const t_analysis* analysis, const t_elf_32_section
 	original->type        = SWAP_NEEDED(analysis, defined->sh_type);
 	original->flags       = SWAP_NEEDED(analysis, defined->sh_flags);
 	original->link        = SWAP_NEEDED(analysis, defined->sh_link);
-	original->offset      = SWAP_NEEDED(analysis, defined->sh_offset);
+	original->sec_offset  = SWAP_NEEDED(analysis, defined->sh_offset);
 	original->entsize     = SWAP_NEEDED(analysis, defined->sh_entsize);
 	original->size        = SWAP_NEEDED(analysis, defined->sh_size);
 	original->info        = SWAP_NEEDED(analysis, defined->sh_info);
@@ -94,6 +94,7 @@ void	map_elf64_symbol(const t_analysis* analysis, const t_elf_64_symbol* defined
 	original->is_debug = false;
 	original->is_global = false;
 	original->is_undefined = false;
+	// DEBUGINFO("defined: %p, original->name_offset: %zu", defined, original->name_offset);
 }
 
 // ELF32シンボル構造体をシンボル構造体にマップする
@@ -124,7 +125,7 @@ void	map_section_to_symbol_table(const t_section_unit* section, t_symbol_table_u
 
 	table->section = section;
 	table->head_addr = section->head_addr;
-	table->offset = section->offset;
+	table->offset = section->sec_offset;
 	table->entry_size = section->entsize;
 	table->total_size = section->size;
 	if (table->entry_size > 0) {
@@ -142,7 +143,7 @@ void	map_section_to_string_table(const t_section_unit* section, t_string_table_u
 
 	table->section = section;
 	table->head_addr = section->head_addr;
-	table->offset = section->offset;
+	table->offset = section->sec_offset;
 	table->total_size = section->size;
 	// 文字列テーブルがNUL-terminatedかどうかチェック
 	if (table->total_size > 0) {

--- a/srcs/symbol.c
+++ b/srcs/symbol.c
@@ -1,7 +1,7 @@
 #include "nm.h"
 
 // シンボルの名前 name を決定する
-void	determine_symbol_name(
+bool	determine_symbol_name(
 	const t_master* m,
 	const t_analysis* analysis,
 	const t_table_pair* table_pair,
@@ -19,11 +19,17 @@ void	determine_symbol_name(
 	} else {
 		const t_string_table_unit* string_table = &table_pair->string_table;
 		if (string_table->is_terminated) {
+			// DEBUGOUT("symbol->name_offset: %zu, string_table->total_size: %zu", symbol->name_offset, string_table->total_size);
+			if (symbol->name_offset > string_table->total_size) {
+				symbol->name = NULL;
+				return false;
+			}
 			symbol->name = string_table->head_addr + symbol->name_offset;
 		} else {
 			symbol->name = NULL;
 		}
 	}
+	return true;
 }
 
 static t_visibility	infer_symbol_visibility(const t_symbol_unit* symbol) {
@@ -42,7 +48,7 @@ static t_visibility	infer_symbol_visibility(const t_symbol_unit* symbol) {
 		default:
 			break;
 	}
-	const bool maybe_global = symbol->name[0] != '_';
+	const bool maybe_global = symbol->name != NULL && symbol->name[0] != '_';
 	return maybe_global ? V_GLOBAL : V_LOCAL;
 }
 


### PR DESCRIPTION
`sh_offset`が適当だと名前周りに被害が出る。